### PR TITLE
Fix CI and Windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,6 @@ to PyPI. (see the "deploy" step in `workflows/ci.yml`). The version number is de
 [hatch-vcs](https://github.com/ofek/hatch-vcs)... which wraps
 [setuptools-scm](https://github.com/pypa/setuptools_scm/)
 
-To auto-deploy to PyPI, you'll need to set a `TWINE_API_KEY` environment
-variable in your github repo settings.  You can get this key from your [pypi
-account](https://pypi.org/manage/account/token/).  Then add it to your github
-repository settings as a secret named `TWINE_API_KEY`. (see [github
-docs](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository))
-
-(the name `TWINE_API_KEY` is specified in `workflows/ci.yml`)
 
 ```sh
 git tag -a v0.1.0 -m v0.1.0
@@ -149,6 +142,16 @@ git push --follow-tags
 # or, specify a remote:
 # git push upstream --follow-tags
 ```
+
+
+To auto-deploy to PyPI, you will need to perform two important steps:
+1. Create a `release` environment in Github
+2. Create a trusted publisher on PyPi
+
+(1) To create the Github environment, go in your Github repository to "Settings > Environemnts". Click on "new environment" and name it `release`, then click on configure. Next, in "Deployment branches", choose "Selected branches" and add a "deploment branch rule". Use `v*.*.*` as branch name patter. This allows the CI to run on Github (see `environment: release` in the "deploy" step in `workflows/ci.yml`)! 
+
+(2) Finally, connect to PyPi (you need an account). Go to your projects and click on "Publishing" (last item on the left menu). In the section "Add a new pending publisher", enter the project name (as in your `pyproject.toml`), the organization or username of the repository owner (on Github) and the repository name. Next, enter `ci.yml` as "Workflow name" and `release` as "Environment name". Add the publisher and you are good to go!
+
 
 ## Update your repo
 

--- a/copier.yml
+++ b/copier.yml
@@ -8,8 +8,8 @@ _skip_if_exists:
 # _tasks:
 #   - git init -q --initial-branch=main || true
 #   - "{{ use_pre_commit }} && pre-commit autoupdate || echo 'please run: pip install pre-commit && pre-commit autoupdate'"
-#   - git add . && 
-#     git commit -q -m 'initial commit' && 
+#   - git add . &&
+#     git commit -q -m 'initial commit' &&
 #     echo 'git repo initialized' || echo 'git init failed'
 
 # ---------- PROMPT --------
@@ -19,6 +19,7 @@ _skip_if_exists:
 mode:
   help: "Welcome! Please select a mode:"
   type: str
+  default: tooling
   choices:
     ✨ Fully featured - default tooling: tooling
     📦 Simple package - minimal tooling: simple
@@ -75,6 +76,7 @@ github_username:
   help: |
     Your GitHub username/organization name
        (If you plan to put your project on GitHub)
+  default: ""
 
 test_pre_release:
   when: "{{ mode == 'customize' }}"

--- a/copier.yml
+++ b/copier.yml
@@ -23,7 +23,7 @@ mode:
   choices:
     ✨ Fully featured - default tooling: tooling
     📦 Simple package - minimal tooling: simple
-    🙋‍♀️ Customize - ask me questions: customize
+    🙋 Customize - ask me questions: customize
 
 project_name:
   help: Name of your project (prefer hyphens to underscores)

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -85,10 +85,14 @@ jobs:
     needs: test
     if: success() && startsWith(github.ref, 'refs/tags/'){% endraw %}{%- if test_pre_release %}{% raw %} && github.event_name != 'schedule'{% endraw %}{% endif %}{% raw %}
     runs-on: ubuntu-latest
+    environment: release # Needs to be created in the gh repository settings
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing on PyPi
       # see https://docs.pypi.org/trusted-publishers/
       id-token: write
+
+      # This permission allows writing releases
+      contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -85,6 +85,10 @@ jobs:
     needs: test
     if: success() && startsWith(github.ref, 'refs/tags/'){% endraw %}{%- if test_pre_release %}{% raw %} && github.event_name != 'schedule'{% endraw %}{% endif %}{% raw %}
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPi
+      # see https://docs.pypi.org/trusted-publishers/
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -103,8 +107,6 @@ jobs:
 
       - name: 🚢 Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TWINE_API_KEY }}
 
       - uses: softprops/action-gh-release@v1
         with:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -42,6 +42,7 @@ def run_copier(tmp_path: Path):
         cmd = ["copier", "--force", str(template), str(dest)]
         for k, v in kwargs.items():
             cmd.extend(["-d", f"{k}={v}"])
+
         run(cmd, check=True)
         return tmp_path
 


### PR DESCRIPTION
https://github.com/pydev-guide/pyrepo-copier/pull/1 did not pass the CI (particularly on Ubuntu which is annoying)


Added the following defaults in the hope of fixing the CI:
- mode
- github name



 