### PR TITLE
Add tooling badges

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -5,5 +5,14 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/{{project_name}}.svg?color=green)](https://python.org)
 [![CI](https://github.com/{{github_username}}/{{project_name}}/actions/workflows/ci.yml/badge.svg)](https://github.com/{{github_username}}/{{project_name}}/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/{{github_username}}/{{project_name}}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{github_username}}/{{project_name}})
+{% if use_ruff -%}
+[![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v0.json)](https://github.com/charliermarsh/ruff) 
+{%- endif -%}
+{%- if use_black %}
+[![code style - Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+{%- endif -%}
+{%- if use_mypy %}
+[![types - Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://github.com/python/mypy) 
+{%- endif -%}
 
 {{project_short_description}}


### PR DESCRIPTION
Not super important, but I stumbled upon tooling badges:

[![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v0.json)](https://github.com/charliermarsh/ruff) 
[![code style - Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
[![types - Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://github.com/python/mypy) 

In case you like them (I am personally not entirely convinced yet ^^), here they are added to the README with the if statements corresponding to the correct tool. :)