### PR TITLE
Fix cli error

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -39,7 +39,7 @@ def template():
 @pytest.fixture
 def run_copier(tmp_path: Path):
     def _copier(template: Path, dest: Path = tmp_path, **kwargs: Any):
-        cmd = ["copier", "--force", str(template), str(dest)]
+        cmd = ["copier", "copy", "--force", str(template), str(dest)]
         for k, v in kwargs.items():
             cmd.extend(["-d", f"{k}={v}"])
 


### PR DESCRIPTION
This fixes the cli error caused by `copier==8.0.0` in the CI. 

However, still one test not passing. The error is due to the fact that ".pre-commit-config.yaml" is not copied over. There seems to be a problem setting the default values. The LICENSE is also not copied over when choosing the "default tooling".

They are added when using the "customize" option. 

For the moment I have not been able to figure out why...