### PR TITLE
numpydoc pre-commit hook

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -107,13 +107,13 @@ use_ruff:
 use_pydocstyle:
   when: "{{ mode == 'customize' and use_pre_commit and use_ruff }}"
   type: bool
-  help: Use pycodestyle rather than numpydoc (stricter) for documentation checking?
+  help: Use pydocstyle (via ruff) for checking documentation compliance?
   default: "{{ use_ruff }}"
 
 use_numpydoc:
   when: "{{ mode == 'customize' and use_pre_commit and not use_pydocstyle }}"
   type: bool
-  help: Use numpydoc for documentation checking?
+  help: Use numpydoc (stricter) for checking documentation compliance?
   default: "{{ not use_pydocstyle and mode != 'simple'}}"
 
 use_mypy:

--- a/copier.yml
+++ b/copier.yml
@@ -113,7 +113,7 @@ use_pydocstyle:
 use_numpydoc:
   when: "{{ mode == 'customize' and use_pre_commit and not use_pydocstyle }}"
   type: bool
-  help: Use numpydoc (stricter) for checking documentation compliance?
+  help: Use numpydoc for checking documentation compliance?
   default: "{{ not use_pydocstyle and mode != 'simple'}}"
 
 use_mypy:

--- a/copier.yml
+++ b/copier.yml
@@ -104,17 +104,17 @@ use_ruff:
   help: Add ruff for linting?
   default: "{{ mode != 'simple' }}"
 
-use_pycodestyle:
+use_pydocstyle:
   when: "{{ mode == 'customize' and use_pre_commit and use_ruff }}"
   type: bool
   help: Use pycodestyle rather than numpydoc (stricter) for documentation checking?
   default: "{{ use_ruff }}"
 
 use_numpydoc:
-  when: "{{ mode == 'customize' and use_pre_commit and not use_pycodestyle }}"
+  when: "{{ mode == 'customize' and use_pre_commit and not use_pydocstyle }}"
   type: bool
   help: Use numpydoc for documentation checking?
-  default: "{{ not use_pycodestyle }}"
+  default: "{{ not use_pydocstyle }}"
 
 use_mypy:
   when: "{{ mode == 'customize' and use_pre_commit }}"

--- a/copier.yml
+++ b/copier.yml
@@ -109,3 +109,9 @@ use_mypy:
   type: bool
   help: Add mypy for static type checking on type hints?
   default: "{{ mode != 'simple' }}"
+
+use_numpydoc:
+  when: "{{ mode == 'customize' and use_pre_commit }}"
+  type: bool
+  help: Add numpydoc for docstring checking?
+  default: "{{ mode != 'simple' }}"

--- a/copier.yml
+++ b/copier.yml
@@ -104,14 +104,20 @@ use_ruff:
   help: Add ruff for linting?
   default: "{{ mode != 'simple' }}"
 
+use_pycodestyle:
+  when: "{{ mode == 'customize' and use_pre_commit and use_ruff }}"
+  type: bool
+  help: Use pycodestyle rather than numpydoc (stricter) for documentation checking?
+  default: "{{ use_ruff }}"
+
+use_numpydoc:
+  when: "{{ mode == 'customize' and use_pre_commit and not use_pycodestyle }}"
+  type: bool
+  help: Use numpydoc for documentation checking?
+  default: "{{ not use_pycodestyle }}"
+
 use_mypy:
   when: "{{ mode == 'customize' and use_pre_commit }}"
   type: bool
   help: Add mypy for static type checking on type hints?
-  default: "{{ mode != 'simple' }}"
-
-use_numpydoc:
-  when: "{{ mode == 'customize' and use_pre_commit }}"
-  type: bool
-  help: Add numpydoc for docstring checking?
   default: "{{ mode != 'simple' }}"

--- a/copier.yml
+++ b/copier.yml
@@ -114,7 +114,7 @@ use_numpydoc:
   when: "{{ mode == 'customize' and use_pre_commit and not use_pydocstyle }}"
   type: bool
   help: Use numpydoc for documentation checking?
-  default: "{{ not use_pydocstyle }}"
+  default: "{{ not use_pydocstyle and mode != 'simple'}}"
 
 use_mypy:
   when: "{{ mode == 'customize' and use_pre_commit }}"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -89,10 +89,8 @@ select = [
     "E",    # style errors
     "W",    # style warnings
     "F",    # flakes
-    {% if use_pydocstyle -%} 
-    "D",    # pydocstyle 
-    {%- endif -%}
-
+    {%- if use_pydocstyle %} 
+    "D",    # pydocstyle {%- endif %}
     "I",    # isort
     "UP",   # pyupgrade
     "C4",   # flake8-comprehensions
@@ -100,8 +98,7 @@ select = [
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
 ]
-
-{% if use_pydocstyle -%} 
+{%- if use_pydocstyle %} 
 ignore = [
     "D100", # Missing docstring in public module
     "D107", # Missing docstring in __init__
@@ -112,18 +109,15 @@ ignore = [
     "D413", # Missing blank line after last section
     "D416", # Section name should end with a colon
 ]
-{%- endif -%}
+{%- endif %}
 
 [tool.ruff.per-file-ignores]
 "tests/*.py" = [
-    
-    {% if use_pydocstyle -%} 
-    "D", 
-    {%- endif -%}
-
+    {%- if use_pydocstyle %} 
+    "D", {%- endif %}
     "S"
 ]
-{%- endif -%}
+{%- endif %}
 
 {%- if use_mypy %}
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -117,8 +117,8 @@ ignore = [
 "tests/*.py" = ["D", "S"]
 "setup.py" = ["D"]
 {%- endif -%}
-{%- if use_mypy %}
 
+{%- if use_mypy %}
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
 files = "src/**/"
@@ -133,6 +133,20 @@ pretty = true
 # module = ["numpy.*",]
 # ignore_errors = true
 {%- endif %}
+
+{%- if use_numpydoc %}
+[tool.numpydoc_validation]
+checks = [
+    "all",  # report on all checks, except the ones below
+    "EX01", # No examples section found
+    "SA01", # See Also section not found
+    "ES01", # No extended summary found
+]
+exclude = [ # don't report on objects that match any of these regex
+    "test_*",
+]
+{%- endif %}
+
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -85,7 +85,6 @@ line-length = 88
 target-version = "py38"
 src = ["src"]
 # https://beta.ruff.rs/docs/rules/
-
 select = [
     "E",    # style errors
     "W",    # style warnings
@@ -93,6 +92,7 @@ select = [
     {% if use_pydocstyle -%} 
     "D",    # pydocstyle 
     {%- endif -%}
+
     "I",    # isort
     "UP",   # pyupgrade
     "C4",   # flake8-comprehensions
@@ -116,9 +116,11 @@ ignore = [
 
 [tool.ruff.per-file-ignores]
 "tests/*.py" = [
+    
     {% if use_pydocstyle -%} 
     "D", 
     {%- endif -%}
+
     "S"
 ]
 {%- endif -%}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -85,11 +85,14 @@ line-length = 88
 target-version = "py38"
 src = ["src"]
 # https://beta.ruff.rs/docs/rules/
+
 select = [
     "E",    # style errors
     "W",    # style warnings
     "F",    # flakes
-    "D",    # pydocstyle
+    {% if use_pydocstyle -%} 
+    "D",    # pydocstyle 
+    {%- endif -%}
     "I",    # isort
     "UP",   # pyupgrade
     "C4",   # flake8-comprehensions
@@ -97,11 +100,8 @@ select = [
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
 ]
-# I do this to get numpy-style docstrings AND retain
-# D417 (Missing argument descriptions in the docstring)
-# otherwise, see:
-# https://beta.ruff.rs/docs/faq/#does-ruff-support-numpy-or-google-style-docstrings
-# https://github.com/charliermarsh/ruff/issues/2606
+
+{% if use_pydocstyle -%} 
 ignore = [
     "D100", # Missing docstring in public module
     "D107", # Missing docstring in __init__
@@ -112,10 +112,15 @@ ignore = [
     "D413", # Missing blank line after last section
     "D416", # Section name should end with a colon
 ]
+{%- endif -%}
 
 [tool.ruff.per-file-ignores]
-"tests/*.py" = ["D", "S"]
-"setup.py" = ["D"]
+"tests/*.py" = [
+    {% if use_pydocstyle -%} 
+    "D", 
+    {%- endif -%}
+    "S"
+]
 {%- endif -%}
 
 {%- if use_mypy %}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -135,6 +135,7 @@ pretty = true
 {%- endif %}
 
 {%- if use_numpydoc %}
+# https://numpydoc.readthedocs.io/en/latest/format.html
 [tool.numpydoc_validation]
 checks = [
     "all",  # report on all checks, except the ones below

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -139,7 +139,7 @@ pretty = true
 # https://numpydoc.readthedocs.io/en/latest/format.html
 [tool.numpydoc_validation]
 checks = [
-    "all",  # report on all checks, except the ones below
+    "all",  # Report on all checks, except the ones below
     "EX01", # No examples section found
     "SA01", # See Also section not found
     "ES01", # No extended summary found

--- a/project/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/project/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
@@ -40,8 +40,8 @@ repos:
 {% endif %}
 {%- if use_numpydoc %}
 
-    - repo: https://github.com/numpy/numpydoc
-      rev: v1.6.0
-      hooks:
-          - id: numpydoc-validation
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.6.0
+    hooks:
+        - id: numpydoc-validation
 {% endif %}

--- a/project/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/project/{% if use_pre_commit %}.pre-commit-config.yaml{% endif %}.jinja
@@ -38,3 +38,10 @@ repos:
         # additional_dependencies:
         #   - numpy
 {% endif %}
+{%- if use_numpydoc %}
+
+    - repo: https://github.com/numpy/numpydoc
+      rev: v1.6.0
+      hooks:
+          - id: numpydoc-validation
+{% endif %}


### PR DESCRIPTION
Add [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) pre-commit hook to enforce numpy docstring format.

Started using this and I am pretty happy with it. There are however some hiccups with mkdocstring, which I have not really examined yet (e.g. md lists not formatted).