### PR TITLE
Some updates to pyproject.toml formatting and ruff rules

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -64,7 +64,7 @@ dev = [
     {%- if use_mypy %}
     "mypy",{%- endif %}
     "pdbpp",  # https://github.com/pdbpp/pdbpp
-    {%- if use_precommit %}
+    {%- if use_pre_commit %}
     "pre-commit",{%- endif %}
     "rich",  # https://github.com/Textualize/rich
     {%- if use_ruff %}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -110,11 +110,11 @@ select = [
     "TCH",  # flake8-type-checking
     # "TID",  # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
 ]
-# I do this to get numpy-style docstrings AND retain
-# D417 (Missing argument descriptions in the docstring)
+# This is to get numpy-style docstrings AND retain D417
+# (Missing argument descriptions in the docstring)
 # otherwise, see:
-# https://beta.ruff.rs/docs/faq/#does-ruff-support-numpy-or-google-style-docstrings
-# https://github.com/charliermarsh/ruff/issues/2606
+# https://docs.astral.sh/ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings
+# https://github.com/astral-sh/ruff/issues/2606
 ignore = [
     "D100", # Missing docstring in public module
     "D107", # Missing docstring in __init__

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -2,9 +2,6 @@
 [build-system]
 requires = ["hatchling"{%- if git_versioning -%}, "hatch-vcs"{%- endif %}]
 build-backend = "hatchling.build"
-# read more about configuring hatch at:
-# https://hatch.pypa.io/latest/config/build/
-
 {%- if git_versioning %}
 
 # https://hatch.pypa.io/latest/config/metadata/
@@ -12,6 +9,8 @@ build-backend = "hatchling.build"
 source = "vcs"
 {%- endif %}
 
+# read more about configuring hatch at:
+# https://hatch.pypa.io/latest/config/build/
 [tool.hatch.build.targets.wheel]
 only-include = ["src"]
 sources = ["src"]
@@ -29,6 +28,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "{{ project_license }}" }
 authors = [{ name = "{{ author_name }}", email = "{{ author_email }}" }]
+# https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 3 - Alpha",
     {%- if project_license == "MIT" %}
@@ -75,6 +75,9 @@ dev = [
 {% if github_username -%}
 homepage = "https://github.com/{{github_username}}/{{project_name}}"
 repository = "https://github.com/{{github_username}}/{{project_name}}"
+{%- else -%}
+# homepage = ""
+# repository = ""
 {%- endif %}
 
 # Entry points
@@ -142,8 +145,8 @@ pretty = true
 # [[tool.mypy.overrides]]
 # module = ["numpy.*",]
 # ignore_errors = true
-
 {%- endif %}
+
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -28,18 +28,25 @@ description = "{{ project_short_description }}"
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "{{ project_license }}" }
-authors = [
-    { name = "{{ author_name }}", email = "{{ author_email }}" },
-]
+authors = [{ name = "{{ author_name }}", email = "{{ author_email }}" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
+    {%- if project_license == "MIT" %}
+    "License :: OSI Approved :: MIT License",
+    {%- elif project_license == "Apache-2.0" %}
+    "License :: OSI Approved :: Apache Software License",
+    {%- elif project_license == "BSD-3-Clause" %}
+    "License :: OSI Approved :: BSD License",
+    {%- elif project_license == "GPL-3.0" %}
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    {%- endif %}
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    # "License :: OSI Approved :: BSD License",
-    # "Typing :: Typed",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 # add your package dependencies here
 dependencies = []
@@ -78,13 +85,14 @@ repository = "https://github.com/{{github_username}}/{{project_name}}"
 
 # [project.entry-points."some.group"]
 # tomatoes = "{{module_name}}:main_tomatoes"
+
 {% if use_ruff -%}
-# https://github.com/charliermarsh/ruff
+# https://docs.astral.sh/ruff
 [tool.ruff]
 line-length = 88
 target-version = "py38"
 src = ["src"]
-# https://beta.ruff.rs/docs/rules/
+# https://docs.astral.sh/ruff/rules
 select = [
     "E",    # style errors
     "W",    # style warnings
@@ -96,6 +104,8 @@ select = [
     "B",    # flake8-bugbear
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
+    "TCH",  # flake8-type-checking
+    # "TID",  # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
 ]
 # I do this to get numpy-style docstrings AND retain
 # D417 (Missing argument descriptions in the docstring)
@@ -132,6 +142,7 @@ pretty = true
 # [[tool.mypy.overrides]]
 # module = ["numpy.*",]
 # ignore_errors = true
+
 {%- endif %}
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
@@ -148,7 +159,10 @@ exclude_lines = [
     "except ImportError",
     "\\.\\.\\.",
     "raise NotImplementedError()",
+    "pass",
 ]
+show_missing = true
+
 [tool.coverage.run]
 source = ["{{module_name}}"]
 
@@ -157,9 +171,7 @@ source = ["{{module_name}}"]
 # (files that are in the repo but shouldn't go in the package)
 [tool.check-manifest]
 ignore = [
-    ".github_changelog_generator",
     ".pre-commit-config.yaml",
     ".ruff_cache/**/*",
-    "setup.py",
     "tests/**/*",
 ]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -108,7 +108,7 @@ select = [
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
     "TCH",  # flake8-type-checking
-    # "TID",  # https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid
+    "TID",  # flake8-tidy-imports
 ]
 # This is to get numpy-style docstrings AND retain D417
 # (Missing argument descriptions in the docstring)


### PR DESCRIPTION
mostly formatting, but also adds:

- https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch - something I think is almost always good to have
- https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid - commented out... slightly opinionated, but something I always enable
