### PR TITLE
tests: fixing tests for copier v9 

### DIFF
--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,12 +6,10 @@ from pathlib import Path
 from subprocess import run
 from typing import Any, Callable
 
-import copier
 import pytest
 import tomli
 
 TEMPLATE = Path(__file__).parent.parent
-COPIER_V8 = copier.__version__.startswith("8.")
 
 
 @contextmanager
@@ -41,7 +39,7 @@ def template():
 @pytest.fixture
 def run_copier(tmp_path: Path):
     def _copier(template: Path, dest: Path = tmp_path, **kwargs: Any):
-        cmd = ["copier", "copy", "--force"] if COPIER_V8 else ["copier", "--force"]
+        cmd = ["copier", "copy", "--force"]
         for k, v in kwargs.items():
             cmd.extend(["-d", f"{k}={v}"])
         cmd.extend([str(template), str(dest)])


### PR DESCRIPTION
just a little change, didn't expect the major version to bump so soon.  only testing on copier >= 8 now