### PR TITLE
Add prompt for minimum supported Python version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -80,7 +80,7 @@ github_username:
 
 minimum_python:
   when: "{{ mode == 'customize' }}"
-  help: What is the minimum Python version you support (https://devguide.python.org/versions/)?
+  help: What is the minimum supported Python version (https://devguide.python.org/versions/)?
   type: int
   default: 9
   choices:

--- a/copier.yml
+++ b/copier.yml
@@ -78,6 +78,18 @@ github_username:
        (If you plan to put your project on GitHub)
   default: ""
 
+minimum_python:
+  when: "{{ mode == 'customize' }}"
+  help: What is the minimum Python version you support (https://devguide.python.org/versions/)?
+  type: int
+  default: 9
+  choices:
+    🐍 3.9: 9
+    🐍 3.10: 10
+    🐍 3.11: 11
+    🐍 3.12: 12
+    🐍 3.13: 13
+
 test_pre_release:
   when: "{{ mode == 'customize' }}"
   help: |

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [{%- if minimum_python <= 9 %}"3.9", {%- endif %}{%- if minimum_python <= 10 %} "3.10",  {%- endif %}{%- if minimum_python <= 11 %} "3.11",  {%- endif %}{%- if minimum_python <= 12 %} "3.12",  {%- endif %}{%- if minimum_python <= 13 %} "3.13"{%- endif %}{% raw %}]
+        python-version: [{%- if minimum_python <= 9 %}"3.9", {% endif %}{% if minimum_python <= 10 %}"3.10", {% endif %}{% if minimum_python <= 11 %}"3.11", {% endif %}{% if minimum_python <= 12 %}"3.12",  {% endif %}{% if minimum_python <= 13 %}"3.13"{% endif %}{% raw %}]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -37,7 +37,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [{%- if minimum_python <= 9 %}"3.9", {% endif %}{% if minimum_python <= 10 %}"3.10", {% endif %}{% if minimum_python <= 11 %}"3.11", {% endif %}{% if minimum_python <= 12 %}"3.12",  {% endif %}{% if minimum_python <= 13 %}"3.13"{% endif %}{% raw %}]
+        python-version: [{%- if minimum_python <= 9 %}"3.9", {% endif -%}
+          {% if minimum_python <= 10 %}"3.10", {% endif -%}
+          {% if minimum_python <= 11 %}"3.11", {% endif -%}
+          {% if minimum_python <= 12 %}"3.12",  {% endif -%}
+          {% if minimum_python <= 13 %}"3.13"{% endif %}{% raw %}]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -33,11 +33,11 @@ jobs:
 {% endif %}{% raw %}
   test:
     name: ${{ matrix.platform }} (${{ matrix.python-version }})
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}{% endraw %}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [{%- if minimum_python <= 9 %}"3.9", {%- endif %}{%- if minimum_python <= 10 %} "3.10",  {%- endif %}{%- if minimum_python <= 11 %} "3.11",  {%- endif %}{%- if minimum_python <= 12 %} "3.12",  {%- endif %}{%- if minimum_python <= 13 %} "3.13"{%- endif %}{% raw %}]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -25,7 +25,7 @@ version = "0.1.0"
 {%- endif %}
 description = "{{ project_short_description }}"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.{{ minimum_python }}"
 license = { text = "{{ project_license }}" }
 authors = [{ name = "{{ author_name }}", email = "{{ author_email }}" }]
 # https://pypi.org/classifiers/
@@ -41,11 +41,21 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     {%- endif %}
     "Programming Language :: Python :: 3",
+    {%- if minimum_python <= 9 %}    
     "Programming Language :: Python :: 3.9",
+    {%- endif %}
+    {%- if minimum_python <= 10 %}
     "Programming Language :: Python :: 3.10",
+    {%- endif %}
+    {%- if minimum_python <= 11 %}
     "Programming Language :: Python :: 3.11",
+    {%- endif %}
+    {%- if minimum_python <= 12 %}
     "Programming Language :: Python :: 3.12",
+    {%- endif %}
+    {%- if minimum_python <= 13 %}
     "Programming Language :: Python :: 3.13",
+    {%- endif %}
     "Typing :: Typed",
 ]
 # add your package dependencies here
@@ -91,7 +101,7 @@ repository = "https://github.com/{{github_username}}/{{project_name}}"
 # https://docs.astral.sh/ruff
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py3{{ minimum_python }}"
 src = ["src"]
 
 # https://docs.astral.sh/ruff/rules


### PR DESCRIPTION
As discussed in #30 , this PR adds a prompt to specify the minimum Python version. The behavior is as follows:

- The default is Python 3.9. 
- For "customized" repos, the user can select the Python version.


The prompt renders as follows:

<img width="1273" alt="Screenshot 2025-01-28 at 20 52 26" src="https://github.com/user-attachments/assets/02139a37-38da-4b78-9680-24350bee5255" />
