### PR TITLE
feat: Update Python version matrix to include 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
note, I accidentally just pushed to main some changes support 3.14, and adding actionlint to the default pre-commit hooks:

https://github.com/pydev-guide/pyrepo-copier/commit/8b8a2dd51213fff10fecb48d2b2edb8719e0d407
