### PR TITLE
add `resolution` option to matrix to test minimum stated deps (opt in)

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -12,7 +12,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,9 @@ name: Test copier
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -26,6 +24,6 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
       - run: uv run pytest tests -v --color=yes

--- a/copier.yml
+++ b/copier.yml
@@ -125,9 +125,3 @@ use_mypy:
   type: bool
   help: Add mypy for static type checking on type hints?
   default: "{{ mode != 'simple' }}"
-
-use_ty:
-  when: "{{ mode == 'customize' and use_pre_commit }}"
-  type: bool
-  help: Add astral-sh/ty for static type checking on type hints?
-  default: "{{ mode != 'simple' and use_mypy == false }}"

--- a/copier.yml
+++ b/copier.yml
@@ -98,6 +98,15 @@ test_pre_release:
   type: bool
   default: "{{ mode != 'simple' }}"
 
+test_lowest_pinned_dependencies:
+  when: "{{ mode == 'customize' }}"
+  type: bool
+  default: false
+  help: |
+    Would you like to test against both highest and lowest pinned dependencies?
+       This adds a resolution matrix to test dependency resolution strategies.
+       (It also requires that you add '>=' to all your deps in pyproject.toml)
+
 use_pre_commit:
   when: "{{ mode == 'customize' }}"
   type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -82,9 +82,8 @@ minimum_python:
   when: "{{ mode == 'customize' }}"
   help: What is the minimum supported Python version (https://devguide.python.org/versions/)?
   type: int
-  default: 9
+  default: 10
   choices:
-    🐍 3.9: 9
     🐍 3.10: 10
     🐍 3.11: 11
     🐍 3.12: 12
@@ -116,3 +115,9 @@ use_mypy:
   type: bool
   help: Add mypy for static type checking on type hints?
   default: "{{ mode != 'simple' }}"
+
+use_ty:
+  when: "{{ mode == 'customize' and use_pre_commit }}"
+  type: bool
+  help: Add astral-sh/ty for static type checking on type hints?
+  default: "{{ mode != 'simple' and use_mypy == false }}"

--- a/copier.yml
+++ b/copier.yml
@@ -84,6 +84,7 @@ minimum_python:
   type: int
   default: 10
   choices:
+    🐍 3.9: 9
     🐍 3.10: 10
     🐍 3.11: 11
     🐍 3.12: 12

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -26,28 +26,34 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: pipx run check-manifest
-{% endif %}{% raw %}
-  test:
-    name: ${{ matrix.platform }} (${{ matrix.python-version }}) [${{ matrix.resolution }}]
+{% endif %}
+  test:{% raw %}
+    name: ${{ matrix.platform }} (${{ matrix.python-version }}){% endraw %}{%- if test_lowest_pinned_dependencies %}{% raw %} [${{ matrix.resolution }}]{% endraw %}{% endif %}{% raw %}
     runs-on: ${{ matrix.platform }}{% endraw %}
-    {%- if test_pre_release %}
+    {%- if test_pre_release or test_lowest_pinned_dependencies %}
     env:
+      {%- if test_pre_release %}
       UV_PRERELEASE: {% raw %}${{ github.event_name == 'schedule' && 'allow' || 'if-necessary-or-explicit' }}{% endraw %}
-      UV_RESOLUTION: ${{ matrix.resolution }}
-      PYTEST_ADDOPTS: ${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}
+      {%- endif %}
+      {%- if test_lowest_pinned_dependencies %}
+      UV_RESOLUTION: {% raw %}${{ matrix.resolution }}{% endraw %}
+      PYTEST_ADDOPTS: {% raw %}${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}{% endraw %}
+      {%- endif %}
     {%- endif %}
     strategy:
       fail-fast: false
       matrix:
         python-version: [{%- if minimum_python <= 9 %}"3.9", {% endif -%}
-          {% if minimum_python <= 10 %}"3.10", {% endif -%}
-          {% if minimum_python <= 11 %}"3.11", {% endif -%}
-          {% if minimum_python <= 12 %}"3.12", {% endif -%}
-          {% if minimum_python <= 12 %}"3.13", {% endif -%}
-          {% if minimum_python <= 13 %}"3.14"{% endif %}{% raw %}]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        resolution: ["highest", "lowest-direct"]
-
+          {%- if minimum_python <= 10 %}"3.10", {% endif -%}
+          {%- if minimum_python <= 11 %}"3.11", {% endif -%}
+          {%- if minimum_python <= 12 %}"3.12", {% endif -%}
+          {%- if minimum_python <= 12 %}"3.13", {% endif -%}
+          {%- if minimum_python <= 13 %}"3.14"{% endif %}{% raw %}]
+        platform: [ubuntu-latest, macos-latest, windows-latest]{% endraw %}
+        {%- if test_lowest_pinned_dependencies %}{% raw %}
+        resolution: ["highest", "lowest-direct"]{% endraw %}
+        {%- endif %}
+{% raw %}
     steps:
       - uses: actions/checkout@v5
 

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -24,15 +24,17 @@ jobs:
   check-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: pipx run check-manifest
 {% endif %}{% raw %}
   test:
-    name: ${{ matrix.platform }} (${{ matrix.python-version }})
+    name: ${{ matrix.platform }} (${{ matrix.python-version }}) [${{ matrix.resolution }}]
     runs-on: ${{ matrix.platform }}{% endraw %}
     {%- if test_pre_release %}
     env:
       UV_PRERELEASE: {% raw %}${{ github.event_name == 'schedule' && 'allow' || 'if-necessary-or-explicit' }}{% endraw %}
+      UV_RESOLUTION: ${{ matrix.resolution }}
+      PYTEST_ADDOPTS: ${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}
     {%- endif %}
     strategy:
       fail-fast: false
@@ -44,9 +46,10 @@ jobs:
           {% if minimum_python <= 12 %}"3.13", {% endif -%}
           {% if minimum_python <= 13 %}"3.14"{% endif %}{% raw %}]
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        resolution: ["highest", "lowest-direct"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: 🐍 Set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
@@ -86,7 +89,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@v2
@@ -105,7 +108,7 @@ jobs:
 
     steps:
       - name: Download built artifact to dist/
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: Packages
           path: dist

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -41,7 +41,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     {%- endif %}
     "Programming Language :: Python :: 3",
-    {%- if minimum_python <= 9 %}    
+    {%- if minimum_python <= 9 %}
     "Programming Language :: Python :: 3.9",
     {%- endif %}
     {%- if minimum_python <= 10 %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "pyrepo-copier"
 version = "0.1.0"
 readme = "README.md"
+requires-python = ">=3.10"
 license = { text = "BSD-3-Clause" }
 
 [tool.mypy]
@@ -20,6 +21,7 @@ norecursedirs = "{{project_name}}"
 
 [dependency-groups]
 dev = [
+    "actionlint-py>=1.7.7.23",
     "check-manifest>=0.50",
     "copier>=9.7.1",
     "pre-commit>=4.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pyrepo-copier"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 
 [tool.mypy]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -76,13 +77,18 @@ def test_copier(template: Path, run_copier: Callable[..., Path]):
 
 def test_bake_and_test(template: Path, run_copier: Callable[..., Path]):
     NAME = "some-project"
-    output = run_copier(template, project_name=NAME, git_init=True)
+    output = run_copier(
+        template,
+        project_name=NAME,
+        git_init=True,
+        minimum_python=sys.version_info.minor,  # use current minor version for CI
+    )
     with inside_dir(str(output)):
         run(["uv", "run", "pytest"], check=True)
 
 
 def test_bake_and_build(template, run_copier: Callable[..., Path]):
-    output = run_copier(template, git_init=True)
+    output = run_copier(template, git_init=True, minimum_python=sys.version_info.minor)
 
     with inside_dir(str(output)):
         run(["uv", "run", "check-manifest"], check=True)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -129,7 +129,7 @@ def test_actionlint_on_rendered_workflow(
     run(["actionlint", str(ci_file)], check=True)
 
     # Verify no resolution matrix in default output
-    ci_content = ci_file.read_text()
+    ci_content = ci_file.read_text(encoding="utf-8")
     is_custom = kwargs["mode"] == "customize"
     assert ("resolution:" in ci_content) is is_custom
     assert ("[${{ matrix.resolution }}]" in ci_content) is is_custom

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -100,3 +100,36 @@ def test_bake_and_pre_commit(template, run_copier: Callable[..., Path]):
         run(["pre-commit", "install"], check=True)
         run(["git", "add", "."], check=True)
         run(["pre-commit", "run", "--all-files"], check=True)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"mode": "simple"},
+        {"mode": "tooling"},
+        {
+            "mode": "customize",
+            "minimum_python": 10,
+            "test_lowest_pinned_dependencies": True,
+            "test_pre_release": True,
+        },
+    ],
+    ids=lambda d: d["mode"],
+)
+def test_actionlint_on_rendered_workflow(
+    template: Path, run_copier: Callable[..., Path], kwargs: dict[str, Any]
+):
+    """Test that the rendered CI workflow passes actionlint validation."""
+    # Test with default settings (should not have resolution matrix)
+    output = run_copier(template, **kwargs)
+    ci_file = output / ".github" / "workflows" / "ci.yml"
+    assert ci_file.exists()
+
+    # Run actionlint on default configuration
+    run(["actionlint", str(ci_file)], check=True)
+
+    # Verify no resolution matrix in default output
+    ci_content = ci_file.read_text()
+    is_custom = kwargs["mode"] == "customize"
+    assert ("resolution:" in ci_content) is is_custom
+    assert ("[${{ matrix.resolution }}]" in ci_content) is is_custom


### PR DESCRIPTION
this PR

- updates used actions to the latest versions
- makes py 3.10 the default  (3.9 is EOL next week) ... though 3.9 is still in the options
- adds an `actionlint` test to make sure the rendered workflows are valid
- **most significant change**: adds a new `resolution: ["highest", "lowest-direct"]` to the matrix.  This (uv-dependent feature) is super useful to make sure that your full dependency constraints work.  Currently off by default, (must be selected in customize) since it requires '>=' for all your pins in pyproject

this ends up looking like this:

```yaml
  test:
    name: ${{ matrix.platform }} (${{ matrix.python-version }}) [${{ matrix.resolution }}]
    runs-on: ${{ matrix.platform }}
    env:
      UV_PRERELEASE: ${{ github.event_name == 'schedule' && 'allow' || 'if-necessary-or-explicit' }}
      UV_RESOLUTION: ${{ matrix.resolution }}
      PYTEST_ADDOPTS: ${{ matrix.resolution == 'lowest-direct' && '-W ignore' || '' }}
    strategy:
      fail-fast: false
      matrix:
        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
        platform: [ubuntu-latest, macos-latest, windows-latest]
        resolution: ["highest", "lowest-direct"]
```